### PR TITLE
Updated index.ts to export CookieValueTypes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { serialize, parse } from 'cookie';
 import { OptionsType, TmpCookiesObj, CookieValueTypes } from './types';
 
+//Declare CookieValueTypes_ to allow usage in ts files outside module scope
+export declare type CookieValueTypes_ = CookieValueTypes;
+
 const isClientSide = (): boolean => typeof window !== 'undefined';
 
 const processValue = (value: string): CookieValueTypes => {


### PR DESCRIPTION
I added a declaration as CookieValueTypes_ to export the type CookieValueTypes to index.d.ts upon compilation by tsc to allow the user to import and use the types in functions they might have to implement.