### PR TITLE
chore: Add JSDoc for deprecated methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,9 @@ export const setCookie = (key: string, data: any, options?: OptionsType): void =
 	}
 };
 
+/**
+ * @deprecated setCookies was deprecated. It will be deleted in the new version. Use setCookie instead.
+ */
 export const setCookies = (key: string, data: any, options?: OptionsType): void => {
 	console.warn('[WARN]: setCookies was deprecated. It will be deleted in the new version. Use setCookie instead.');
 	return setCookie(key, data, options);
@@ -110,6 +113,9 @@ export const deleteCookie = (key: string, options?: OptionsType): void => {
 	return setCookie(key, '', { ...options, maxAge: -1 });
 };
 
+/**
+ * @deprecated removeCookies was deprecated. It will be deleted in the new version. Use deleteCookie instead.
+ */
 export const removeCookies = (key: string, options?: OptionsType): void => {
 	console.warn('[WARN]: removeCookies was deprecated. It will be deleted in the new version. Use deleteCookie instead.');
 	return deleteCookie(key, options);
@@ -122,6 +128,9 @@ export const hasCookie = (key: string,  options?: OptionsType): boolean => {
 	return cookie.hasOwnProperty(key);
 };
 
+/**
+ * @deprecated checkCookies was deprecated. It will be deleted in the new version. Use hasCookie instead.
+ */
 export const checkCookies = (key: string,  options?: OptionsType): boolean => {
 	console.warn('[WARN]: checkCookies was deprecated. It will be deleted in the new version. Use hasCookie instead.');
 	return hasCookie(key, options);


### PR DESCRIPTION
Hello, @andreizanik 
I am one of the developers who is using your package well, first of all, thank you very much for creating such a convenient package

Recently, while using this package again, I found out that there were methods that were deprecated and that the developer using this method did not know that it was deprecated until he actually called the method and met console.warn.

I added JSDoc to increase DX, and I would appreciate it if you could review it.

## Overview

I Add JSDoc for deprecated methods (setCookies, removeCookies, checkCookies)

## Screenshots

Before

<img width="775" alt="image" src="https://github.com/andreizanik/cookies-next/assets/57122180/2c80d18f-224f-4c18-9517-b4d4042a66ef">


After

<img width="769" alt="image" src="https://github.com/andreizanik/cookies-next/assets/57122180/4129dc28-a15b-4aae-9f52-a4609e2844fd">
