### PR TITLE
Add missing import to the "Client Example" [Documentation]

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ as the first argument to the function and when server side rendering, this funct
 #### Client Example
 
 ```js
-import { getCookies, setCookie, deleteCookie } from 'cookies-next';
+import { getCookies, setCookie, deleteCookie, getCookie } from 'cookies-next';
 
 // we can use it anywhere
 getCookies();


### PR DESCRIPTION
Hello! 

Recently, I noticed a minor mistake in the documentation. The method getCookie should have been imported in the "Client Example," but it was missing. I have corrected this issue.