### PR TITLE
Middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Getting, setting and removing cookies with NEXT.JS
 - can be used on the client side, anywhere
 - can be used for server side rendering in getServerSideProps
 - can be used in API handlers
+- can be used in appDir middleware
+- can be used in appDir route handlers
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -34,11 +34,12 @@
   },
   "homepage": "https://github.com/andreizanik/cookies-next#readme",
   "dependencies": {
-    "cookie": "^0.4.0",
     "@types/cookie": "^0.4.1",
-    "@types/node": "^16.10.2"
+    "@types/node": "^16.10.2",
+    "cookie": "^0.4.0"
   },
   "devDependencies": {
+    "next": "^13.4.19",
     "typescript": "^4.4.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,11 +91,12 @@ export const getCookie = (key: string, options?: OptionsType): CookieValueTypes 
 export const setCookie = (key: string, data: any, options?: OptionsType): void => {
   if (isContextFromAppRouterMiddleware(options)) {
     const { req, res, ...restOptions } = options;
+    const payload = { name: key, value: data, ...restOptions };
     if (req) {
-      req.cookies.set({ name: key, value: data, ...restOptions });
+      req.cookies.set(payload);
     }
     if (res) {
-      res.cookies.set({ name: key, value: data, ...restOptions });
+      res.cookies.set(payload);
     }
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ const isCookiesFromAppRouterMiddleware = (
   cookieStore: TmpCookiesObj | AppRouterMiddlewareCookies | undefined,
 ): cookieStore is AppRouterMiddlewareCookies => {
   if (!cookieStore) return false;
-  return 'getAll' && 'set' in cookieStore && typeof cookieStore.getAll === 'function';
+  return (
+    'getAll' &&
+    'set' in cookieStore &&
+    typeof cookieStore.getAll === 'function' &&
+    typeof cookieStore.set === 'function'
+  );
 };
 
 const isContextFromAppRouterMiddleware = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,11 +84,22 @@ export const getCookie = (key: string, options?: OptionsType): CookieValueTypes 
 };
 
 export const setCookie = (key: string, data: any, options?: OptionsType): void => {
+  if (isContextFromAppRouterMiddleware(options)) {
+    const { req, res, ...restOptions } = options;
+    if (req) {
+      req.cookies.set({ name: key, value: data, ...restOptions });
+    }
+    if (res) {
+      res.cookies.set({ name: key, value: data, ...restOptions });
+    }
+    return;
+  }
   let _cookieOptions: any;
   let _req;
   let _res;
   if (options) {
-    const { req, res, ..._options } = options;
+    // DefaultOptions can be casted here because the AppRouterMiddlewareOptions is narrowed using the fn: isContextFromAppRouterMiddleware
+    const { req, res, ..._options } = options as DefaultOptions;
     _req = req;
     _res = res;
     _cookieOptions = _options;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface DefaultOptions extends CookieSerializeOptions {
     cookies?: TmpCookiesObj;
   };
 }
-export type AppRouterMiddlewareOptions = { res: Response | NextResponse; req?: Request | NextRequest };
+export type AppRouterMiddlewareOptions = { res?: Response | NextResponse; req?: Request | NextRequest };
 export type AppRouterMiddlewareCookies = NextResponse['cookies'] | NextRequest['cookies'];
 export type TmpCookiesObj = { [key: string]: string } | Partial<{ [key: string]: string }>;
 export type CookieValueTypes = string | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,15 @@
 import { CookieSerializeOptions } from 'cookie';
 import { IncomingMessage, ServerResponse } from 'http';
+import type { NextRequest, NextResponse } from 'next/server';
 
-export interface OptionsType extends CookieSerializeOptions {
+export type OptionsType = DefaultOptions | AppRouterMiddlewareOptions;
+export interface DefaultOptions extends CookieSerializeOptions {
   res?: ServerResponse;
   req?: IncomingMessage & {
-    cookies?: { [key: string]: string } | Partial<{ [key: string]: string }>;
+    cookies?: TmpCookiesObj;
   };
 }
-
+export type AppRouterMiddlewareOptions = { res: Response | NextResponse; req?: Request | NextRequest };
+export type AppRouterMiddlewareCookies = NextResponse['cookies'] | NextRequest['cookies'];
 export type TmpCookiesObj = { [key: string]: string } | Partial<{ [key: string]: string }>;
 export type CookieValueTypes = string | undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "declaration": true,
-    "outDir": "./lib",
-    "strict": true
-  },
-  "include": ["src"],
-  "exclude": ["node_modules", "tib", "**/__tests__/*"]
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": true,
+        "outDir": "./lib",
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "tib", "**/__tests__/*"]
 }


### PR DESCRIPTION
Hi, 

I've added support for middleware. Both the **`setCookie`** and **`getCookie`** functions now include a guard statement responsible for detecting middleware context. If the guard detects middleware context, methods attached to **`res.cookies`** will be called. I had to install Next v13 as a devDependency because both the **`NextResponse`** and **`NextRequest`** types were too complex to rewrite, and I needed to import those types directly..

I would appreciate a code review, and I would be grateful if my changes could be considered for merging.

This pr refers to #12 