### PR TITLE
Extend Next.js 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Getting, setting and removing cookies with NEXT.JS
 - can be used on the client side, anywhere
 - can be used for server side rendering in getServerSideProps
 - can be used in API handlers
-- can be used in appDir middleware
-- can be used in appDir route handlers
+- can be used in Next.js 13+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ export default async function handler(req, res) {
 `/app/api/hello/route.ts`
 
 ```ts
+import { cookies } from 'next/headers';
 import type { NextRequest, NextResponse } from 'next/server';
 import { deleteCookie, getCookie, setCookie, hasCookie, getCookies } from 'cookies-next';
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,20 @@ If you pass ctx (Next.js context) in function, then this function will be done o
 If the function should be done only on client or can't get ctx, pass null or {}
 as the first argument to the function and when server side rendering, this function return undefined;
 
-#### Client Example
+In Next.js 13+, you can [read(only)](https://nextjs.org/docs/app/api-reference/functions/cookies) cookies in `Server Components` and read/update them in `Server Actions`. This can be achieved by using the `cookies` function as an option, which is imported from `next/headers`, instead of using `req` and `res`.
+
+#### Client -  App Router Example
+
+```ts
+'use client'
+import { getCookies, setCookie, deleteCookie, getCookie } from 'cookies-next';
+
+getCookies();
+getCookie('key');
+setCookie('key', 'value');
+deleteCookie('key');
+```
+#### Client - Pages Router Example
 
 ```js
 import { getCookies, setCookie, deleteCookie, getCookie } from 'cookies-next';
@@ -97,7 +110,34 @@ setCookie('key', 'value');
 deleteCookie('key');
 ```
 
-#### SSR Example
+#### SSR - App Router Example
+
+`/app/page.tsx`
+
+```tsx
+import { setCookie, getCookie, getCookies, deleteCookie, hasCookie } from 'cookies-next';
+import { cookies } from 'next/headers';
+
+const Home = async () => {
+  // It's not possible to update the cookie in RSC
+  ❌ setCookie("test", "value", { cookies }); 👉🏻// Won't work.
+  ❌ deleteCookie('test1', { cookies }); 👉🏻// Won't work.
+  
+  ✔️ getCookie('test1', { cookies });
+  ✔️ getCookies({ cookies });
+  ✔️ hasCookie('test1', { cookies });
+
+  return (
+    <main>
+      <h1>Hello cookies next</h1>
+    </main>
+  );
+};
+
+export default Home;
+
+```
+#### SSR - Pages Router Example
 
 `/page/index.js`
 
@@ -120,8 +160,26 @@ export const getServerSideProps = ({ req, res }) => {
 
 export default Home;
 ```
+#### SSR - Server Actions Example
+```ts
+'use server';
 
-#### API Example
+import { cookies } from 'next/headers';
+import { setCookie, deleteCookie, hasCookie, getCookie, getCookies } from 'cookies-next';
+
+export async function testAction() {
+  setCookie('test', 'value', { cookies });
+  getCookie('test', { cookies });
+  getCookies({ cookies });
+  hasCookie('test', { cookies });
+  deleteCookie('test', { cookies });
+}
+
+
+
+```
+
+#### API - Pages Router Example
 
 `/page/api/example.js`
 
@@ -138,6 +196,55 @@ export default async function handler(req, res) {
   return res.status(200).json({ message: 'ok' });
 }
 ```
+#### API - App Router Example
+
+`/app/api/hello/route.ts`
+
+```ts
+import type { NextRequest, NextResponse } from 'next/server';
+import { deleteCookie, getCookie, setCookie, hasCookie, getCookies } from 'cookies-next';
+
+export async function GET(req: NextRequest) {
+  const res = new NextResponse();
+  setCookie('test', 'value', { res, req });
+  getCookie('test', { res, req });
+  getCookies({ res, req });
+  deleteCookie('test', { res, req });
+  hasCookie('test', { req, res });
+
+  // provide cookies fn
+  setCookie('test1', 'value', { cookies });
+  getCookie('test1', { cookies });
+  getCookies({ cookies });
+  deleteCookie('test1', { cookies });
+  hasCookie('test1', { cookies });
+
+  return res;
+}
+
+```
+#### Middleware 
+
+```ts
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getCookie, setCookie, deleteCookie, hasCookie, getCookies } from 'cookies-next';
+import { cookies } from 'next/headers';
+
+export function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  setCookie('test', 'value', { res, req });
+  hasCookie('test', { req, res });
+  deleteCookie('test', { res, req });
+  getCookie('test', { res, req });
+  getCookies({ res, req });
+
+  ❌ setCookie('test', 'value', { cookies }); 👉🏻// Won't work.
+  // It's not possible to use cookies function from next/headers in middleware.
+  return res;
+}
+
+```
 
 ## API
 
@@ -148,6 +255,7 @@ setCookie('key', 'value', options);
 
 setCookie('key', 'value'); // - client side
 setCookie('key', 'value', { req, res }); // - server side
+setCookie({ cookies }); // - server side(route handlers, server actions)
 ```
 
 ## getCookies(options);
@@ -155,13 +263,15 @@ setCookie('key', 'value', { req, res }); // - server side
 ```js
 getCookies(); // - client side
 getCookies({ req, res }); // - server side
+getCookies({ cookies }); // - server side(route handlers, server actions, server components, middleware)
 ```
 
 ## getCookie(key, options);
 
 ```js
-getCookie('key'); - client side
-getCookie('key', { req, res }); - server side
+getCookie('key'); // - client side
+getCookie('key', { req, res }); // - server side
+getCookie('key', { cookies }); // - server side(route handlers, server actions, server components, middleware)
 ```
 
 ## hasCookie(key, options);
@@ -169,6 +279,7 @@ getCookie('key', { req, res }); - server side
 ```js
 hasCookie('key'); // - client side
 hasCookie('key', { req, res }); // - server side
+hasCookie('key', { cookies }); // server side(route handlers, server actions, server components, middleware)
 ```
 
 ### deleteCookie(key, options);
@@ -176,6 +287,7 @@ hasCookie('key', { req, res }); // - server side
 ```js
 deleteCookie('key'); // - client side
 deleteCookie('key', { req, res }); // - server side
+deleteCookie('key', { cookies }); // - server side(route handlers, server actions)
 ```
 
 _IMPORTANT! When deleting a cookie and you're not relying on the default attributes,
@@ -198,11 +310,15 @@ cookie's value
 
 ##### req
 
-required for server side cookies (API and getServerSideProps)
+required for server side cookies (route handlers, middleware, API and getServerSideProps)
 
 ##### res
 
-required for server side cookies (API and getServerSideProps)
+required for server side cookies (route handlers, middleware, API and getServerSideProps)
+
+##### cookies
+
+required for server actions and can be used in route handlers
 
 ##### domain
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type {
   OptionsType,
   TmpCookiesObj,
   CookieValueTypes,
-  AppRouterMiddlewareCookies,
+  AppRouterCookies,
   DefaultOptions,
   CookiesFn,
 } from './types';
@@ -12,9 +12,9 @@ export { CookieValueTypes } from './types';
 
 const isClientSide = (): boolean => typeof window !== 'undefined';
 
-const isCookiesFromAppRouterMiddleware = (
-  cookieStore: TmpCookiesObj | AppRouterMiddlewareCookies | undefined,
-): cookieStore is AppRouterMiddlewareCookies => {
+const isCookiesFromAppRouter = (
+  cookieStore: TmpCookiesObj | AppRouterCookies | undefined,
+): cookieStore is AppRouterCookies => {
   if (!cookieStore) return false;
   return (
     'getAll' &&
@@ -24,17 +24,17 @@ const isCookiesFromAppRouterMiddleware = (
   );
 };
 
-const isContextFromAppRouterMiddleware = (
+const isContextFromAppRouter = (
   context?: OptionsType,
 ): context is { res?: NextResponse; req?: NextRequest; cookies?: CookiesFn } => {
   return (
-    (!!context?.req && 'cookies' in context.req && isCookiesFromAppRouterMiddleware(context?.req.cookies)) ||
-    (!!context?.res && 'cookies' in context.res && isCookiesFromAppRouterMiddleware(context?.res.cookies)) ||
-    (!!context?.cookies && isCookiesFromAppRouterMiddleware(context.cookies()))
+    (!!context?.req && 'cookies' in context.req && isCookiesFromAppRouter(context?.req.cookies)) ||
+    (!!context?.res && 'cookies' in context.res && isCookiesFromAppRouter(context?.res.cookies)) ||
+    (!!context?.cookies && isCookiesFromAppRouter(context.cookies()))
   );
 };
 
-const transformAppRouterMiddlewareCookies = (cookies: AppRouterMiddlewareCookies): TmpCookiesObj => {
+const transformAppRouterCookies = (cookies: AppRouterCookies): TmpCookiesObj => {
   let _cookies: Partial<TmpCookiesObj> = {};
 
   cookies.getAll().forEach(({ name, value }) => {
@@ -59,17 +59,17 @@ const decode = (str: string): string => {
 };
 
 export const getCookies = (options?: OptionsType): TmpCookiesObj => {
-  if (isContextFromAppRouterMiddleware(options)) {
+  if (isContextFromAppRouter(options)) {
     if (options?.req) {
-      return transformAppRouterMiddlewareCookies(options.req.cookies);
+      return transformAppRouterCookies(options.req.cookies);
     }
     if (options?.cookies) {
-      return transformAppRouterMiddlewareCookies(options.cookies());
+      return transformAppRouterCookies(options.cookies());
     }
   }
 
   let req;
-  // DefaultOptions['req] can be casted here because is narrowed by using the fn: isContextFromAppRouterMiddleware
+  // DefaultOptions['req] can be casted here because is narrowed by using the fn: isContextFromAppRouter
   if (options) req = options.req as DefaultOptions['req'];
 
   if (!isClientSide()) {
@@ -104,7 +104,7 @@ export const getCookie = (key: string, options?: OptionsType): CookieValueTypes 
 };
 
 export const setCookie = (key: string, data: any, options?: OptionsType): void => {
-  if (isContextFromAppRouterMiddleware(options)) {
+  if (isContextFromAppRouter(options)) {
     const { req, res, cookies: cookiesFn, ...restOptions } = options;
     const payload = { name: key, value: data, ...restOptions };
     if (req) {
@@ -122,7 +122,7 @@ export const setCookie = (key: string, data: any, options?: OptionsType): void =
   let _req;
   let _res;
   if (options) {
-    // DefaultOptions can be casted here because the AppRouterMiddlewareOptions is narrowed using the fn: isContextFromAppRouterMiddleware
+    // DefaultOptions can be casted here because the AppRouterMiddlewareOptions is narrowed using the fn: isContextFromAppRouter
     const { req, res, ..._options } = options as DefaultOptions;
     _req = req;
     _res = res;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import type { NextRequest, NextResponse } from 'next/server';
 import type { cookies } from 'next/headers';
 
-export type OptionsType = DefaultOptions | AppRouterMiddlewareOptions; // try conditional
+export type OptionsType = DefaultOptions | AppRouterOptions;
 export interface DefaultOptions extends CookieSerializeOptions {
   res?: ServerResponse;
   req?: IncomingMessage & {
@@ -13,11 +13,11 @@ export interface DefaultOptions extends CookieSerializeOptions {
 }
 
 export type CookiesFn = typeof cookies;
-export type AppRouterMiddlewareOptions = {
+export type AppRouterOptions = {
   res?: Response | NextResponse;
   req?: Request | NextRequest;
   cookies?: CookiesFn;
 };
-export type AppRouterMiddlewareCookies = NextResponse['cookies'] | NextRequest['cookies'];
+export type AppRouterCookies = NextResponse['cookies'] | NextRequest['cookies'];
 export type TmpCookiesObj = { [key: string]: string } | Partial<{ [key: string]: string }>;
 export type CookieValueTypes = string | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,23 @@
 import { CookieSerializeOptions } from 'cookie';
 import { IncomingMessage, ServerResponse } from 'http';
 import type { NextRequest, NextResponse } from 'next/server';
+import type { cookies } from 'next/headers';
 
-export type OptionsType = DefaultOptions | AppRouterMiddlewareOptions;
+export type OptionsType = DefaultOptions | AppRouterMiddlewareOptions; // try conditional
 export interface DefaultOptions extends CookieSerializeOptions {
   res?: ServerResponse;
   req?: IncomingMessage & {
     cookies?: TmpCookiesObj;
   };
+  cookies?: CookiesFn;
 }
-export type AppRouterMiddlewareOptions = { res?: Response | NextResponse; req?: Request | NextRequest };
+
+export type CookiesFn = typeof cookies;
+export type AppRouterMiddlewareOptions = {
+  res?: Response | NextResponse;
+  req?: Request | NextRequest;
+  cookies?: CookiesFn;
+};
 export type AppRouterMiddlewareCookies = NextResponse['cookies'] | NextRequest['cookies'];
 export type TmpCookiesObj = { [key: string]: string } | Partial<{ [key: string]: string }>;
 export type CookieValueTypes = string | undefined;


### PR DESCRIPTION
Hello!

I've extended support for Next.js 13+. Now it's possible to access and update cookies in various places. Here's what I've done in this pull request:

- Added support for the **`cookies`** function exported from **`next/headers`**.
- Renamed types.
- Extended the documentation.

In summary, with the recent updates in this pull request and PR #51, you can perform the following actions in the new features of Next.js 13+:

- **Update cookies (set/delete):** client components, middleware, route handlers, server actions.
- **Get/check cookies:** server components, client components, middleware, route handlers, server actions.

NOTE: It is not possible to update cookies in the context of React Server Components.

Enjoy

This PR refers to:  #44,  #52 #57