### PR TITLE
move @types/* to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "homepage": "https://github.com/andreizanik/cookies-next#readme",
   "dependencies": {
-    "@types/cookie": "^0.6.0",
-    "@types/node": "^16.10.2",
     "cookie": "^0.6.0"
   },
   "devDependencies": {
+    "@types/cookie": "^0.6.0",
+    "@types/node": "^16.10.2",
     "next": "^13.4.19",
     "prettier": "^3.0.2",
     "typescript": "^4.4.3"


### PR DESCRIPTION
they are only needed during build. having them in dependencies pollutes prod builds