### PR TITLE
chore: move @types/cookie to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   },
   "homepage": "https://github.com/andreizanik/cookies-next#readme",
   "dependencies": {
-    "cookie": "^0.6.0"
+    "cookie": "^0.6.0",
+    "@types/cookie": "^0.6.0"
   },
   "devDependencies": {
-    "@types/cookie": "^0.6.0",
     "@types/node": "^16.10.2",
     "next": "^13.4.19",
     "prettier": "^3.0.2",


### PR DESCRIPTION
**Refer to #71**

**Summary:**
This PR addresses a type error that occurs when using `NextApiRequest` and `NextApiResponse` in a Next.js API route handler. The error is due to the incorrect type inference of `cookies`, which defaults to `AppRouterOptions` instead of `DefaultOptions`. This PR ensures that the type of `cookies` is correctly listed in the dependency, preventing the type error.

**Code Changes:**
- move `@types/cookies` to dependency to prevent missing type 
