### PR TITLE
Update cookie dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/andreizanik/cookies-next#readme",
   "dependencies": {
-    "cookie": "^0.6.0",
+    "cookie": "^0.7.0",
     "@types/cookie": "^0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to update the npm package, cookie, that cookie-next depends on. This was found to have a severe vulnerability (https://github.com/advisories/GHSA-pxg6-pf52-xh8x).