### PR TITLE
Bumps up support range for next js to support the latest patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "next": ">=15.0.0"
+    "next": ">=15.0.3"
   }
 }


### PR DESCRIPTION
I have used 15.0.3 and it works great with your package but I keep having to use `--legacy-peer-deps` to install npm. Hopefully you think it's fine to bump it up too